### PR TITLE
[FEAT-13] 회원정보 관련 조회 수정 기능 추가

### DIFF
--- a/src/main/java/project/domain/cart/Cart.java
+++ b/src/main/java/project/domain/cart/Cart.java
@@ -27,7 +27,7 @@ public class Cart extends BaseEntity {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @OneToMany(fetch = LAZY)
+    @OneToMany(fetch = LAZY,mappedBy = "cart", cascade = CascadeType.ALL)
     private List<CartItem> cartItemList = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/project/domain/member/Member.java
+++ b/src/main/java/project/domain/member/Member.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.domain.common.BaseEntity;
+import project.domain.member.dto.MemberRequest.UpdateDTO;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -23,7 +24,7 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "member_id")
     private Long id;
 
     @Column(nullable = false)
@@ -82,5 +83,18 @@ public class Member extends BaseEntity {
         this.role = Role.USER;
         this.area = area;
         this.lang = lang;
+    }
+
+
+    public void updateMember(UpdateDTO updateDTO) {
+        this.nickname = updateDTO.getNickname();
+        this.profileImg = updateDTO.getProfileImg();
+        this.email = updateDTO.getEmail();
+        this.birth = updateDTO.getBirth();
+        this.gender = Gender.valueOf(updateDTO.getGender());
+        this.skinType = SkinType.valueOf(updateDTO.getSkinType());
+        this.personalType = PersonalType.valueOf(updateDTO.getPersonalType());
+        this.area = Area.valueOf(updateDTO.getArea());
+        this.lang = Language.valueOf(updateDTO.getLang());
     }
 }

--- a/src/main/java/project/domain/member/controller/MemberController.java
+++ b/src/main/java/project/domain/member/controller/MemberController.java
@@ -1,16 +1,29 @@
 package project.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import project.domain.member.Member;
 import project.domain.member.dto.MemberRequest.JoinDTO;
+import project.domain.member.dto.MemberRequest.UpdateDTO;
+import project.domain.member.dto.MemberRequest.UpdatePasswordDTO;
+import project.domain.member.dto.MemberResponse.DetailInfoDTO;
 import project.domain.member.service.MemberService;
 import project.global.response.ApiResponse;
+import project.global.response.exception.GeneralException;
+import project.global.response.status.ErrorStatus;
+import project.global.security.annotation.LoginMember;
 
+
+@Tag(name = "회원 API", description = "회원 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
@@ -18,18 +31,70 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(
+        summary = "회원 가입",
+        description = "사용자로부터 회원 정보를 받아 회원가입을 처리합니다."
+    )
     @PostMapping("/join")
     public ApiResponse<Boolean> createMember(
-        JoinDTO joinDTO
+        @RequestBody JoinDTO joinDTO
     ) {
         return memberService.join(joinDTO);
     }
 
+    @Operation(
+        summary = "닉네임 중복확인",
+        description = "사용자로부터 닉네임을 받아 중복을 확인합니다."
+    )
     @GetMapping("/check")
     public ApiResponse<Boolean> checkNickname(
         @RequestParam String nickname
     ) {
-        boolean b = memberService.checkMemberByNickname(nickname);
-        return ApiResponse.onSuccess(b);
+        boolean chk = memberService.checkMemberByNickname(nickname);
+        if(chk) {
+            return ApiResponse.onSuccess(true);
+        }else{
+            throw new GeneralException(ErrorStatus.MEMBER_DUPLICATE_BY_NICKNAME);
+        }
     }
+
+    @Operation(
+        summary = "사용자 정보 조회",
+        description = "사용자의 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping
+    public ApiResponse<DetailInfoDTO> getMemberInfo(
+        @LoginMember Member member
+    ) {
+        return memberService.getMemberDetailInfo(member);
+    }
+
+    @Operation(
+        summary = "사용자 정보 수정",
+        description = "사용자로부터 수정할 정보를 받아 수정합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PatchMapping
+    public ApiResponse<DetailInfoDTO> updateMember(
+        @LoginMember Member member,
+        @RequestBody UpdateDTO updateDTO
+    ) {
+        return memberService.updateMember(member, updateDTO);
+    }
+
+    @Operation(
+        summary = "비밀번호 수정",
+        description = "사용자로부터 새로운 비밀번호를 받고 수정해줍니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PatchMapping("/new-password")
+    public ApiResponse<Boolean> changePassword(
+        @LoginMember Member member,
+        @RequestBody UpdatePasswordDTO updatePasswordDTO
+    ) {
+        memberService.createNewPassword(member, updatePasswordDTO.getPassword());
+        return ApiResponse.onSuccess(true);
+    }
+
 }

--- a/src/main/java/project/domain/member/dto/MemberConverter.java
+++ b/src/main/java/project/domain/member/dto/MemberConverter.java
@@ -7,11 +7,13 @@ import project.domain.member.Member;
 import project.domain.member.PersonalType;
 import project.domain.member.SkinType;
 import project.domain.member.dto.MemberRequest.JoinDTO;
+import project.domain.member.dto.MemberResponse.DetailInfoDTO;
 
 public abstract class MemberConverter {
 
     public static Member toEntity(JoinDTO dto) {
         return Member.builder()
+            .nickname(dto.getNickname())
             .email(dto.getEmail())
             .gender(Gender.valueOf(dto.getGender()))
             .birth(dto.getBirth())
@@ -20,6 +22,21 @@ public abstract class MemberConverter {
             .skinType(SkinType.valueOf(dto.getSkinType()))
             .lang(Language.valueOf(dto.getLang()))
             .build();
+    }
+
+    public static DetailInfoDTO toDetailInfoDTO(Member member) {
+        return DetailInfoDTO.builder()
+            .email(member.getEmail())
+            .nickname(member.getNickname())
+            .birth(member.getBirth())
+            .profileImg(member.getProfileImg())
+            .area(member.getArea().toString())
+            .skinType(member.getSkinType().toString())
+            .gender(member.getGender().toString())
+            .personalType(member.getPersonalType().toString())
+            .language(member.getLang().toString())
+            .build();
+
     }
 
 }

--- a/src/main/java/project/domain/member/dto/MemberRequest.java
+++ b/src/main/java/project/domain/member/dto/MemberRequest.java
@@ -12,7 +12,7 @@ public abstract class MemberRequest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class JoinDTO{
+    public static class JoinDTO {
 
         @NotNull
         String nickname;
@@ -30,7 +30,7 @@ public abstract class MemberRequest {
         String gender;
 
         @NotNull
-        String  area;
+        String area;
 
         @NotNull
         String lang;
@@ -38,5 +38,44 @@ public abstract class MemberRequest {
         String skinType;
 
         String personalType;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateDTO {
+
+        @NotNull
+        String nickname;
+
+        @NotNull
+        LocalDate birth;
+
+        @NotNull
+        String email;
+
+        @NotNull
+        String gender;
+
+        @NotNull
+        String area;
+
+        @NotNull
+        String lang;
+
+        String profileImg;
+
+        String skinType;
+
+        String personalType;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdatePasswordDTO {
+
+        @NotNull
+        String password;
     }
 }

--- a/src/main/java/project/domain/member/dto/MemberResponse.java
+++ b/src/main/java/project/domain/member/dto/MemberResponse.java
@@ -1,0 +1,36 @@
+package project.domain.member.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class MemberResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DetailInfoDTO {
+
+        public String nickname;
+
+        public String profileImg;
+
+        public String email;
+
+        public LocalDate birth;
+
+        public String gender;
+
+        public String skinType;
+
+        public String personalType;
+
+        public String area;
+
+        public String language;
+    }
+
+}

--- a/src/main/java/project/domain/member/service/MemberService.java
+++ b/src/main/java/project/domain/member/service/MemberService.java
@@ -1,13 +1,15 @@
 package project.domain.member.service;
 
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.domain.member.Member;
 import project.domain.member.dto.MemberConverter;
+import project.domain.member.dto.MemberRequest;
 import project.domain.member.dto.MemberRequest.JoinDTO;
+import project.domain.member.dto.MemberResponse;
+import project.domain.member.dto.MemberResponse.DetailInfoDTO;
 import project.domain.member.repository.MemberRepository;
 import project.global.response.ApiResponse;
 import project.global.response.exception.GeneralException;
@@ -22,14 +24,20 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+
+    // 회원가입
     @Transactional
     public ApiResponse<Boolean> join(JoinDTO joinDTO) {
 
         memberRepository.findByEmail(joinDTO.getEmail())
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_DUPLICATE_BY_EMAIL));
+            .ifPresent(member -> {
+                throw new GeneralException(ErrorStatus.MEMBER_DUPLICATE_BY_EMAIL);
+            });
 
         memberRepository.findByNickname(joinDTO.getNickname())
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND_BY_Nickname));
+            .ifPresent(member -> {
+                throw new GeneralException(ErrorStatus.MEMBER_DUPLICATE_BY_NICKNAME);
+            });
 
         Member entity = MemberConverter.toEntity(joinDTO);
         entity.setPassword(bCryptPasswordEncoder.encode(joinDTO.getPassword()));
@@ -45,19 +53,46 @@ public class MemberService {
         );
     }
 
+    // 새로운 비밀번호를 생성
     @Transactional
     public void createNewPassword(Member member, String password) {
         member.setPassword(bCryptPasswordEncoder.encode(password));
         memberRepository.save(member);
     }
 
+    // 멤버의 정보 조회
+    public ApiResponse<MemberResponse.DetailInfoDTO> getMemberDetailInfo(Member member) {
+        Member memberById = findMemberById(member);
+        DetailInfoDTO detailInfoDTO = MemberConverter.toDetailInfoDTO(memberById);
+        return ApiResponse.onSuccess(detailInfoDTO);
+    }
+
+    // 멤버 정보 수정
+    @Transactional
+    public ApiResponse<MemberResponse.DetailInfoDTO> updateMember(Member member,
+        MemberRequest.UpdateDTO updateDTO) {
+        Member memberById = findMemberById(member);
+
+        memberById.updateMember(updateDTO);
+        memberRepository.save(memberById);
+
+        DetailInfoDTO detailInfoDTO = MemberConverter.toDetailInfoDTO(memberById);
+        return ApiResponse.onSuccess(detailInfoDTO);
+    }
+
     public Member findMemberByNickname(String nickname) {
         return memberRepository.findByNickname(nickname)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_DUPLICATE_BY_NICKNAME));
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND_BY_NICKNAME));
     }
 
     public boolean checkMemberByNickname(String nickname) {
-        return memberRepository.findByNickname(nickname).isPresent();
+        return memberRepository.findByNickname(nickname).isEmpty();
+
+    }
+
+    private Member findMemberById(Member member) {
+        return memberRepository.findById(member.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
 

--- a/src/main/java/project/global/response/status/ErrorStatus.java
+++ b/src/main/java/project/global/response/status/ErrorStatus.java
@@ -32,7 +32,7 @@ public enum ErrorStatus {
     /*
      * member
      */
-    MEMBER_NOT_FOUND_BY_Nickname(HttpStatus.BAD_REQUEST, "MEMBER4000",
+    MEMBER_NOT_FOUND_BY_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4000",
         "해당 닉네임를 가진 회원이 존재하지 않습니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4001",
         "해당 email을 가진 회원이 존재하지 않습니다."),
@@ -42,6 +42,8 @@ public enum ErrorStatus {
         , "이미 있는 닉네임입니다."),
     MEMBER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4003",
         "잘못된 비밀번호 입니다. "),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4004",
+    "해당 멤버가 존재하지 않습니다."),
 
     ;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
1. member 관련 crud 기능을 추가하였습니다.

Resolves: #13

## #️⃣ 요약 설명

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
> ex) 기존 memberInfoDTO response 값에 생일을 추가했습니다.

```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
