### PR TITLE
[FIX-17] : 언어 Enum 값 변경

### DIFF
--- a/src/main/java/project/domain/member/Member.java
+++ b/src/main/java/project/domain/member/Member.java
@@ -12,6 +12,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.domain.common.BaseEntity;
 import project.domain.member.dto.MemberRequest.UpdateDTO;
+import project.domain.member.enums.Area;
+import project.domain.member.enums.Gender;
+import project.domain.member.enums.Language;
+import project.domain.member.enums.PersonalType;
+import project.domain.member.enums.Role;
+import project.domain.member.enums.SkinType;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/project/domain/member/dto/MemberConverter.java
+++ b/src/main/java/project/domain/member/dto/MemberConverter.java
@@ -1,11 +1,14 @@
 package project.domain.member.dto;
 
-import project.domain.member.Area;
-import project.domain.member.Gender;
-import project.domain.member.Language;
+import static project.domain.member.enums.EnumUtil.safeValueOf;
+import static project.domain.member.enums.EnumUtil.toStringSafe;
+
+import project.domain.member.enums.Area;
+import project.domain.member.enums.Gender;
+import project.domain.member.enums.Language;
 import project.domain.member.Member;
-import project.domain.member.PersonalType;
-import project.domain.member.SkinType;
+import project.domain.member.enums.PersonalType;
+import project.domain.member.enums.SkinType;
 import project.domain.member.dto.MemberRequest.JoinDTO;
 import project.domain.member.dto.MemberResponse.DetailInfoDTO;
 
@@ -18,8 +21,8 @@ public abstract class MemberConverter {
             .gender(Gender.valueOf(dto.getGender()))
             .birth(dto.getBirth())
             .area(Area.valueOf(dto.getArea()))
-            .personalType(PersonalType.valueOf(dto.getPersonalType()))
-            .skinType(SkinType.valueOf(dto.getSkinType()))
+            .personalType(safeValueOf(PersonalType.class,dto.getPersonalType()))
+            .skinType(safeValueOf(SkinType.class,dto.getSkinType()))
             .lang(Language.valueOf(dto.getLang()))
             .build();
     }
@@ -31,12 +34,11 @@ public abstract class MemberConverter {
             .birth(member.getBirth())
             .profileImg(member.getProfileImg())
             .area(member.getArea().toString())
-            .skinType(member.getSkinType().toString())
+            .skinType(toStringSafe(member.getSkinType()))
             .gender(member.getGender().toString())
-            .personalType(member.getPersonalType().toString())
+            .personalType(toStringSafe(member.getPersonalType()))
             .language(member.getLang().toString())
             .build();
-
     }
 
 }

--- a/src/main/java/project/domain/member/enums/Area.java
+++ b/src/main/java/project/domain/member/enums/Area.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum Area {
     KOREAN,

--- a/src/main/java/project/domain/member/enums/EnumUtil.java
+++ b/src/main/java/project/domain/member/enums/EnumUtil.java
@@ -1,0 +1,16 @@
+package project.domain.member.enums;
+
+public abstract class EnumUtil {
+    public static <T extends Enum<T>> T safeValueOf(Class<T> enumClass, String value) {
+        if (value == null) return null;
+        try {
+            return Enum.valueOf(enumClass, value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public static String toStringSafe(Enum<?> e) {
+        return e != null ? e.toString() : null;
+    }
+}

--- a/src/main/java/project/domain/member/enums/Gender.java
+++ b/src/main/java/project/domain/member/enums/Gender.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum Gender {
     MALE, FEMALE, OTHER

--- a/src/main/java/project/domain/member/enums/Language.java
+++ b/src/main/java/project/domain/member/enums/Language.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum Language {
     KR, EN, JP

--- a/src/main/java/project/domain/member/enums/PersonalType.java
+++ b/src/main/java/project/domain/member/enums/PersonalType.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum PersonalType {
     TYPE_A, TYPE_B, TYPE_C

--- a/src/main/java/project/domain/member/enums/Role.java
+++ b/src/main/java/project/domain/member/enums/Role.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum Role {
     USER, ADMIN

--- a/src/main/java/project/domain/member/enums/SkinType.java
+++ b/src/main/java/project/domain/member/enums/SkinType.java
@@ -1,4 +1,4 @@
-package project.domain.member;
+package project.domain.member.enums;
 
 public enum SkinType {
     OILY, DRY, COMBINATION, NORMAL

--- a/src/main/java/project/global/security/filter/JwtAuthFilter.java
+++ b/src/main/java/project/global/security/filter/JwtAuthFilter.java
@@ -3,7 +3,7 @@ package project.global.security.filter;
 import static project.global.response.status.ErrorStatus.AUTHENTICATION_TYPE_IS_NOT_BEARER;
 import static project.global.response.status.ErrorStatus.TOKEN_IS_EXPIRED;
 
-import project.domain.member.Role;
+import project.domain.member.enums.Role;
 import project.global.response.status.ErrorStatus;
 import project.global.security.util.JwtUtil;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/project/global/security/filter/LoginFilter.java
+++ b/src/main/java/project/global/security/filter/LoginFilter.java
@@ -1,7 +1,7 @@
 package project.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import project.domain.member.Role;
+import project.domain.member.enums.Role;
 import project.global.security.dto.UserDetailsDTO;
 import project.global.security.service.redis.RefreshTokenService;
 import project.global.security.util.CookieUtil;

--- a/src/main/java/project/global/security/util/JwtUtil.java
+++ b/src/main/java/project/global/security/util/JwtUtil.java
@@ -1,6 +1,6 @@
 package project.global.security.util;
 
-import project.domain.member.Role;
+import project.domain.member.enums.Role;
 import project.global.security.service.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;


### PR DESCRIPTION
1. 회원가입 또는 조회시 피부타입에 관한 null 값을 허용해주었습니다.

Resolves : #17

## #️⃣ 요약 설명

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
>  기존 Enum에 관해 공통 유효성 검증 로직을 추가하였습니다.


```java
package project.domain.member.enums;

public abstract class EnumUtil {
    public static <T extends Enum<T>> T safeValueOf(Class<T> enumClass, String value) {
        if (value == null) return null;
        try {
            return Enum.valueOf(enumClass, value);
        } catch (IllegalArgumentException e) {
            return null;
        }
    }

    public static String toStringSafe(Enum<?> e) {
        return e != null ? e.toString() : null;
    }
}

```

- *safeValueOf*
   - Enum값으로 변환시 Null 유효성 처리를 해줍니다.
   - String 값으로 변환신 Null 유효성 처리를 해줍니다.  

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
