### PR TITLE
[FIX-21] 피부 설문조사 다국어 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
 
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.4'

--- a/src/main/java/project/domain/mbti/MbtiQuestion.java
+++ b/src/main/java/project/domain/mbti/MbtiQuestion.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.domain.member.enums.Language;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +36,10 @@ public class MbtiQuestion {
 
     @Enumerated(EnumType.STRING)
     private Step step;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Language language;
 
     private int nextQuestionId;
 

--- a/src/main/java/project/domain/mbti/controller/MbtiQuestionController.java
+++ b/src/main/java/project/domain/mbti/controller/MbtiQuestionController.java
@@ -27,8 +27,9 @@ public class MbtiQuestionController {
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/questions")
     public ApiResponse<QuestionInfoList> getTestQuestion(
-        @RequestParam String axis
+        @RequestParam String axis,
+        @RequestParam String lang
     ) {
-        return mbtiQuestionService.getQuestionInfoList(axis);
+        return mbtiQuestionService.getQuestionInfoList(axis,lang);
     }
 }

--- a/src/main/java/project/domain/mbti/repository/MbtiQuestionRepository.java
+++ b/src/main/java/project/domain/mbti/repository/MbtiQuestionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import project.domain.mbti.MbtiQuestion;
 import project.domain.mbti.SkinAxis;
+import project.domain.member.enums.Language;
 
 public interface MbtiQuestionRepository extends JpaRepository<MbtiQuestion, Long> {
 
@@ -16,9 +17,11 @@ public interface MbtiQuestionRepository extends JpaRepository<MbtiQuestion, Long
     /*
         질문의 시작을 기준으로 가져오는 쿼리
      */
-    @Query("SELECT q FROM MbtiQuestion q WHERE q.axis = :axis " +
+    @Query("SELECT q FROM MbtiQuestion q WHERE q.axis = :axis and q.language= :lang " +
         "ORDER BY CASE WHEN q.step = 'START' THEN 0 ELSE 1 END, q.questionId ASC")
-    List<MbtiQuestion> findByAxisOrderByStartFirst(@Param("axis") SkinAxis axis);
+    List<MbtiQuestion> findByAxisOrderByStartFirst(
+        @Param("axis") SkinAxis axis,
+        @Param("lang") Language language);
 
 
 }

--- a/src/main/java/project/domain/mbti/service/MbtiQuestionService.java
+++ b/src/main/java/project/domain/mbti/service/MbtiQuestionService.java
@@ -11,6 +11,7 @@ import project.domain.mbti.dto.MbtiQuestionConverter;
 import project.domain.mbti.dto.MbtiQuestionResponse;
 import project.domain.mbti.dto.MbtiQuestionResponse.QuestionInfoList;
 import project.domain.mbti.repository.MbtiQuestionRepository;
+import project.domain.member.enums.Language;
 import project.global.response.ApiResponse;
 import project.global.response.exception.GeneralException;
 import project.global.response.status.ErrorStatus;
@@ -22,9 +23,10 @@ public class MbtiQuestionService {
 
     private final MbtiQuestionRepository mbtiQuestionRepository;
 
-    public ApiResponse<QuestionInfoList> getQuestionInfoList(String axis) {
+    public ApiResponse<QuestionInfoList> getQuestionInfoList(String axis,String lang) {
 
-        List<MbtiQuestion> byAxis = mbtiQuestionRepository.findByAxisOrderByStartFirst(SkinAxis.valueOf(axis));
+        List<MbtiQuestion> byAxis = mbtiQuestionRepository.findByAxisOrderByStartFirst(SkinAxis.valueOf(axis),
+            Language.getLanguage(lang));
         QuestionInfoList questionInfoList = MbtiQuestionConverter.toQuestionInfoList(byAxis);
 
         return ApiResponse.onSuccess(questionInfoList);


### PR DESCRIPTION
1. 기존 질문API에 언어 Params 추가

#Resolves : #21

## #️⃣ 요약 설명

## 📝 작업 내용

> ### GET /mbti/questions 메서드의 params를 추가했습니다.

```java
@Operation(
        summary = "피부 Mbti 테스트 질문 조회",
        description = "mbit 테스트 질문을 축별로 조회를 합니다."
    )
    @SecurityRequirement(name = "bearerAuth")
    @GetMapping("/questions")
    public ApiResponse<QuestionInfoList> getTestQuestion(
        @RequestParam String axis,
        @RequestParam String lang
    ) {
        return mbtiQuestionService.getQuestionInfoList(axis,lang);
    }
```

## 동작 확인

> 
> <img width="1431" alt="스크린샷 2025-06-09 오후 12 14 07" src="https://github.com/user-attachments/assets/b3730e28-15d2-4ecf-9ff6-7d767e8c2cd7" />

> <img width="1415" alt="스크린샷 2025-06-09 오후 12 14 27" src="https://github.com/user-attachments/assets/59dda18c-9dec-4608-80f6-924c2f2a8bd4" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
