### PR TITLE
[FS2-63 FEAT] : 사용자 테이블에 mbti 추가

### DIFF
--- a/src/main/java/project/domain/mbti/SkinAxis.java
+++ b/src/main/java/project/domain/mbti/SkinAxis.java
@@ -3,7 +3,6 @@ package project.domain.mbti;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @RequiredArgsConstructor
@@ -15,7 +14,7 @@ public enum SkinAxis {
 
     private final String string;
 
-    public static SkinAxis getSkinAxis(String axis) {
+    public static SkinAxis getString(String axis) {
         return Arrays.stream(SkinAxis.values())
             .filter(axis1 -> axis1.string.equals(axis))
             .findFirst()

--- a/src/main/java/project/domain/mbti/Step.java
+++ b/src/main/java/project/domain/mbti/Step.java
@@ -7,7 +7,7 @@ public enum Step {
     B,
     F,
     S,
-    A,
+    R,
     W;
 
     public static Boolean checkEnd(Step step) {

--- a/src/main/java/project/domain/member/dto/MemberConverter.java
+++ b/src/main/java/project/domain/member/dto/MemberConverter.java
@@ -3,6 +3,7 @@ package project.domain.member.dto;
 import static project.domain.member.enums.EnumUtil.safeValueOf;
 import static project.domain.member.enums.EnumUtil.toStringSafe;
 
+import project.domain.mbti.Step;
 import project.domain.member.enums.Area;
 import project.domain.member.enums.Gender;
 import project.domain.member.enums.Language;
@@ -21,8 +22,11 @@ public abstract class MemberConverter {
             .gender(Gender.valueOf(dto.getGender()))
             .birth(dto.getBirth())
             .area(Area.valueOf(dto.getArea()))
-            .personalType(safeValueOf(PersonalType.class,dto.getPersonalType()))
-            .skinType(safeValueOf(SkinType.class,dto.getSkinType()))
+            .personalType(safeValueOf(PersonalType.class, dto.getPersonalType()))
+            .skinType(SkinType.getSkinType(dto.getSkinType()))
+            .pigmentType(safeValueOf(Step.class, dto.getPigmentType()))
+            .moistureType(safeValueOf(Step.class, dto.getMoistureType()))
+            .reactivityType(safeValueOf(Step.class, dto.getReactivityType()))
             .lang(Language.getLanguage(dto.getLanguage()))
             .build();
     }
@@ -34,7 +38,8 @@ public abstract class MemberConverter {
             .birth(member.getBirth())
             .profileImg(member.getProfileImg())
             .area(member.getArea().toString())
-            .skinType(toStringSafe(member.getSkinType()))
+            .skinType(member.getSkinType() != null ? member.getSkinType().getString() : "")
+            .mbtiCode(member.createMbti())
             .gender(member.getGender().toString())
             .personalType(toStringSafe(member.getPersonalType()))
             .language(member.getLang().toString())

--- a/src/main/java/project/domain/member/dto/MemberRequest.java
+++ b/src/main/java/project/domain/member/dto/MemberRequest.java
@@ -37,6 +37,15 @@ public abstract class MemberRequest {
 
         String skinType;
 
+        // 색소축관한 타입
+        String pigmentType;
+
+        // 수분/유분 관한 타입
+        String moistureType;
+
+        // 반응성 관한 타입
+        String reactivityType;
+
         String personalType;
     }
 
@@ -60,6 +69,12 @@ public abstract class MemberRequest {
         String profileImg;
 
         String skinType;
+
+        String pigmentType;
+
+        String moistureType;
+
+        String reactivityType;
 
         String personalType;
     }

--- a/src/main/java/project/domain/member/dto/MemberResponse.java
+++ b/src/main/java/project/domain/member/dto/MemberResponse.java
@@ -28,6 +28,9 @@ public abstract class MemberResponse {
 
         public String personalType;
 
+        // 사용자의 mbti에 관한 코드
+        public String mbtiCode;
+
         public String area;
 
         public String language;

--- a/src/main/java/project/global/enums/skin/SkinType.java
+++ b/src/main/java/project/global/enums/skin/SkinType.java
@@ -1,8 +1,23 @@
 package project.global.enums.skin;
 
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum SkinType {
-    건성,
-    지성,
-    복합성,
-    민감성
+    A("건성"),
+    O("지성"),
+    N("복합성");
+
+    private final String string;
+
+    public static SkinType getSkinType(String skinType) {
+        return Arrays.stream(SkinType.values())
+            .filter(type -> type.string.equals(skinType))
+            .findFirst()
+            .orElse(null);
+    }
+
 }


### PR DESCRIPTION
1. 사용자 테이블에 mbti 필드를 추가했습니다.

2. 조회 수정 기능을 추가했습니다.

Resolves : #40

## #️⃣ 요약 설명

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
> ex) 기존 memberInfoDTO response 값에 생일을 추가했습니다.

> ### SkinType enum 변경
```java
package project.global.enums.skin;

import java.util.Arrays;
import lombok.Getter;
import lombok.RequiredArgsConstructor;

@Getter
@RequiredArgsConstructor
public enum SkinType {
    A("건성"),
    O("지성"),
    N("복합성");

    private final String string;

    public static SkinType getSkinType(String skinType) {
        return Arrays.stream(SkinType.values())
            .filter(type -> type.string.equals(skinType))
            .findFirst()
            .orElse(null);
    }

}

```

> ### Member 엔티티 mbti 관련 코드 추가
```java
  // 색소축
    @Enumerated(EnumType.STRING)
    private Step pigmentType;

    // 수분/유분
    @Enumerated(EnumType.STRING)
    private Step moistureType;

    // 반응성
    @Enumerated(EnumType.STRING)
    private Step reactivityType;
```

## 동작 확인
> <img width="1437" alt="스크린샷 2025-06-12 오후 3 13 45" src="https://github.com/user-attachments/assets/32ec0458-4171-4365-b576-a73fb7d3efc9" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
