### PR TITLE
[FS2-69  FIX] : 구매내역 조회 기능 수정

### DIFF
--- a/src/main/java/project/domain/purchasehistory/PurchaseHistory.java
+++ b/src/main/java/project/domain/purchasehistory/PurchaseHistory.java
@@ -41,13 +41,17 @@ public class PurchaseHistory extends BaseEntity {
     @Column(name = "img_url", columnDefinition = "TEXT")
     private String imgUrl;
 
+    private String itemOption;
+
     @Builder
-    private PurchaseHistory(Member member, Long itemId, String itemName, Integer price, Integer quantity, String imgUrl) {
+    private PurchaseHistory(Member member, Long itemId, String itemName, Integer price,
+        Integer quantity, String imgUrl, String itemOption) {
         this.member = member;
         this.itemId = itemId;
         this.itemName = itemName;
         this.price = price;
         this.quantity = quantity;
         this.imgUrl = imgUrl;
+        this.itemOption = itemOption != null ? itemOption : "default";
     }
 }

--- a/src/main/java/project/domain/purchasehistory/controller/PurchaseHistoryController.java
+++ b/src/main/java/project/domain/purchasehistory/controller/PurchaseHistoryController.java
@@ -1,6 +1,8 @@
 package project.domain.purchasehistory.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import project.domain.member.Member;
+import project.domain.purchasehistory.dto.PurchaseHistoryResponse;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.DetailInfoListDTO;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.InfoListDTO;
 import project.domain.purchasehistory.service.PurchaseHistoryService;
@@ -40,9 +43,11 @@ public class PurchaseHistoryController {
         summary = "상세 구매 내역 조회",
         description = "날짜 관련 상세 구매내역을 조회합니다."
     )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공",
+        content = @Content(schema = @Schema(implementation = PurchaseHistoryResponse.DetailInfoListDTO.class)))
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/detail")
-    public ApiResponse<DetailInfoListDTO> getPurchaseHistoryDetail(
+    public ApiResponse<PurchaseHistoryResponse.DetailInfoListDTO> getPurchaseHistoryDetail(
         @LoginMember Member member,
         @RequestParam LocalDate date
     ){

--- a/src/main/java/project/domain/purchasehistory/dto/PurchaseHistoryConverter.java
+++ b/src/main/java/project/domain/purchasehistory/dto/PurchaseHistoryConverter.java
@@ -10,22 +10,23 @@ import project.domain.purchasehistory.PurchaseHistory;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.DateInfoListDTO;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.DetailInfoDTO;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.DetailInfoListDTO;
+import project.domain.purchasehistory.dto.PurchaseHistoryResponse.HistoryDTO;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.InfoListDTO;
 
 public abstract class PurchaseHistoryConverter {
 
     private static DateInfoListDTO toDateInfoList(
-        List<String> imgList,
+        List<HistoryDTO> historys,
         LocalDate localDate
     ) {
         return DateInfoListDTO.builder()
             .date(localDate)
-            .imgUrlList(imgList)
+            .historys(historys)
             .build();
     }
 
     public static InfoListDTO toInfoListDTO(
-        Map<LocalDate, List<String>> groupedByDate
+        Map<LocalDate, List<HistoryDTO>> groupedByDate
     ) {
         List<DateInfoListDTO> dateInfoList = groupedByDate.entrySet().stream()
             .map(entry -> toDateInfoList(entry.getValue(), entry.getKey()))
@@ -43,6 +44,7 @@ public abstract class PurchaseHistoryConverter {
             .quantity(purchaseHistory.getQuantity())
             .price(purchaseHistory.getPrice())
             .imgUrl(purchaseHistory.getImgUrl())
+            .itemOption(purchaseHistory.getItemOption())
             .build();
     }
 

--- a/src/main/java/project/domain/purchasehistory/dto/PurchaseHistoryResponse.java
+++ b/src/main/java/project/domain/purchasehistory/dto/PurchaseHistoryResponse.java
@@ -10,20 +10,38 @@ import lombok.NoArgsConstructor;
 public abstract class PurchaseHistoryResponse {
 
 
+    /*
+        날짜 별 구매내역 전체 보기
+     */
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class DateInfoListDTO{
+    public static class DateInfoListDTO {
+
         private LocalDate date;
-        private List<String> imgUrlList;
+        private List<HistoryDTO> historys;
+    }
+
+    /*
+        구매내역 전체 보기 이미지 Url과 아이템 Id
+     */
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class HistoryDTO {
+
+        private Long id;
+        private String imgUrl;
     }
 
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class InfoListDTO{
+    public static class InfoListDTO {
+
         private List<DateInfoListDTO> dateInfoList;
     }
 
@@ -31,21 +49,28 @@ public abstract class PurchaseHistoryResponse {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class DetailInfoListDTO{
+    public static class DetailInfoListDTO {
+
         private List<DetailInfoDTO> detailInfoList;
         private Integer totalPrice;
     }
 
+
+    /*
+        구매내약 상세보기 아이템 정보
+     */
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class DetailInfoDTO{
+    public static class DetailInfoDTO {
+
         private Long itemId;
         private String itemName;
         private String imgUrl;
         private Integer price;
         private Integer quantity;
+        private String itemOption;
     }
 
 }

--- a/src/main/java/project/domain/purchasehistory/service/PurchaseHistoryService.java
+++ b/src/main/java/project/domain/purchasehistory/service/PurchaseHistoryService.java
@@ -14,6 +14,7 @@ import project.domain.member.Member;
 import project.domain.purchasehistory.PurchaseHistory;
 import project.domain.purchasehistory.dto.PurchaseHistoryConverter;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.DetailInfoListDTO;
+import project.domain.purchasehistory.dto.PurchaseHistoryResponse.HistoryDTO;
 import project.domain.purchasehistory.dto.PurchaseHistoryResponse.InfoListDTO;
 import project.domain.purchasehistory.repository.PurchaseHistoryRepository;
 import project.global.response.ApiResponse;
@@ -33,10 +34,12 @@ public class PurchaseHistoryService {
         List<PurchaseHistory> purchaseHistoryByMemberId = purchaseHistoryRepository.findByMemberId(
             member.getId());
 
-        Map<LocalDate, List<String>> groupedByDate = purchaseHistoryByMemberId.stream()
+        Map<LocalDate, List<HistoryDTO>> groupedByDate = purchaseHistoryByMemberId.stream()
             .collect(Collectors.groupingBy(
-                ph-> ph.getCreatedAt().toLocalDate(),
-                Collectors.mapping(PurchaseHistory::getImgUrl, Collectors.toList())
+                ph -> ph.getCreatedAt().toLocalDate(),
+                Collectors.mapping(
+                    ph -> HistoryDTO.builder().imgUrl(ph.getImgUrl()).id(ph.getId()).build(),
+                    Collectors.toList())
             ));
 
         InfoListDTO infoListDTO = PurchaseHistoryConverter.toInfoListDTO(groupedByDate);


### PR DESCRIPTION
1. 상세보기에 itemOption 필드를 추가했습니다.

2. 전체보기에 itemid를 추가하였습니다.

Resolves : #52

## #️⃣ 요약 설명

## 📝 작업 내용

> itemOption 필드를 추가하였습니다. 기존값은 default
```java

@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class PurchaseHistory extends BaseEntity {

    @Id
    @GeneratedValue(strategy = IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
    private Member member;

    @Column(name = "item_id", nullable = false)
    private Long itemId;

    @Column(name = "item_name", nullable = false, length = 200)
    private String itemName;

    @Column(nullable = false)
    private Integer price;

    @Column(nullable = false)
    private Integer quantity;

    @Column(name = "img_url", columnDefinition = "TEXT")
    private String imgUrl;

    private String itemOption;

```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

### 구매내역 전체보기
> <img width="1470" alt="스크린샷 2025-06-16 오후 3 30 09" src="https://github.com/user-attachments/assets/924b91a0-3c15-46c6-91c4-9a0af46ac776" />
> <img width="1468" alt="스크린샷 2025-06-16 오후 3 29 56" src="https://github.com/user-attachments/assets/ef062c7c-238a-4fa2-a294-81801df8e18b" />

### 상세보기 
> <img width="1473" alt="스크린샷 2025-06-16 오후 3 28 48" src="https://github.com/user-attachments/assets/514a1bfe-757d-4f8b-9439-dce16a6099f3" />

## 💬 리뷰 요구사항(선택)

