### PR TITLE
[FS2-70, 71, 72] 리뷰 옵션 테이블 수정, 상품 추천 테이블 필드 추가, 상품 추천 테이블 필드 추가

### DIFF
--- a/src/main/java/project/domain/cart/repository/CartRepository.java
+++ b/src/main/java/project/domain/cart/repository/CartRepository.java
@@ -7,6 +7,5 @@ import project.domain.member.Member;
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
-    Optional<Cart> findByMember(Member member);
     Optional<Cart> findByMemberId(Long memberId);
 }

--- a/src/main/java/project/domain/item/Item.java
+++ b/src/main/java/project/domain/item/Item.java
@@ -15,7 +15,7 @@ import project.domain.item.enums.VeganType;
 import project.domain.itemimage.ItemImage;
 import project.domain.itemoption.ItemOption;
 import project.domain.itemscore.ItemScore;
-import project.domain.reviewoptionlist.ReviewOptionList;
+import project.domain.makeupreviewoptionlist.MakeupReviewOptionList;
 import project.domain.subcategory.SubCategory;
 
 import java.util.ArrayList;
@@ -46,6 +46,9 @@ public class Item extends BaseEntity {
     private SubCategory subCategory;
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = LAZY)
+    private List<MakeupReviewOptionList> makeUpReviewOptionList;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = LAZY)
     private List<Inventory> inventories = new ArrayList<>();
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = LAZY)
@@ -65,9 +68,6 @@ public class Item extends BaseEntity {
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = LAZY)
     private List<Graph> graphs = new ArrayList<>();
-
-    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, fetch = LAZY)
-    private List<ReviewOptionList> reviewOptionLists = new ArrayList<>();
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/project/domain/itemscore/ItemScore.java
+++ b/src/main/java/project/domain/itemscore/ItemScore.java
@@ -27,4 +27,6 @@ public class ItemScore extends BaseEntity {
 
     private int score;
 
+    private String smallCategory;
+
 }

--- a/src/main/java/project/domain/makeupreviewoption/MakeupReviewOption.java
+++ b/src/main/java/project/domain/makeupreviewoption/MakeupReviewOption.java
@@ -1,13 +1,13 @@
-package project.domain.subcategory;
+package project.domain.makeupreviewoption;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.domain.common.BaseEntity;
-import project.domain.item.Item;
 import project.domain.makeupreviewoptionlist.MakeupReviewOptionList;
-import project.domain.reviewoption.ReviewOption;
+import project.global.enums.skin.PersonalType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,19 +18,23 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SubCategory extends BaseEntity {
+public class MakeupReviewOption extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "subCategory", fetch = LAZY)
-    private List<Item> item = new ArrayList<>();
+    @OneToMany(mappedBy = "makeupReviewOption", cascade = CascadeType.ALL, fetch = LAZY)
+    private List<MakeupReviewOptionList> makeupReviewOptionList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "subCategory", fetch = LAZY)
-    private List<ReviewOption> reviewOptionList = new ArrayList<>();
-
-    @Column(nullable = false)
     private String name;
 
+    private String opt1;
+
+    private String opt2;
+
+    private String opt3;
+
+    @Nullable
+    private String opt4;
 }

--- a/src/main/java/project/domain/makeupreviewoption/repository/MakeupReviewOptionRepository.java
+++ b/src/main/java/project/domain/makeupreviewoption/repository/MakeupReviewOptionRepository.java
@@ -1,0 +1,8 @@
+package project.domain.makeupreviewoption.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.domain.makeupreviewoption.MakeupReviewOption;
+
+public interface MakeupReviewOptionRepository extends JpaRepository<MakeupReviewOption, Long> {
+
+}

--- a/src/main/java/project/domain/makeupreviewoptionlist/MakeupReviewOptionList.java
+++ b/src/main/java/project/domain/makeupreviewoptionlist/MakeupReviewOptionList.java
@@ -1,4 +1,4 @@
-package project.domain.reviewoptionlist;
+package project.domain.makeupreviewoptionlist;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -6,7 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.domain.common.BaseEntity;
 import project.domain.item.Item;
-import project.domain.reviewoption.ReviewOption;
+import project.domain.makeupreviewoption.MakeupReviewOption;
+import project.domain.subcategory.SubCategory;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -14,7 +15,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewOptionList extends BaseEntity {
+public class MakeupReviewOptionList extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -25,7 +26,7 @@ public class ReviewOptionList extends BaseEntity {
     private Item item;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "review_option_id")
-    private ReviewOption reviewOption;
+    @JoinColumn(name = "makeup_review_option_id")
+    private MakeupReviewOption makeupReviewOption;
 
 }

--- a/src/main/java/project/domain/makeupreviewoptionlist/repository/MakeupReviewOptionListRepository.java
+++ b/src/main/java/project/domain/makeupreviewoptionlist/repository/MakeupReviewOptionListRepository.java
@@ -1,0 +1,18 @@
+package project.domain.makeupreviewoptionlist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import project.domain.makeupreviewoption.MakeupReviewOption;
+import project.domain.makeupreviewoptionlist.MakeupReviewOptionList;
+
+import java.util.List;
+
+public interface MakeupReviewOptionListRepository extends JpaRepository<MakeupReviewOptionList, Long> {
+
+    @Query("""
+            SELECT s FROM MakeupReviewOptionList s
+            LEFT JOIN FETCH s.makeupReviewOption r
+            WHERE (s.item.id = :itemId)
+            """)
+    List<MakeupReviewOptionList> findByItemIdWithReviewOptions(Long itemId);
+}

--- a/src/main/java/project/domain/member/Member.java
+++ b/src/main/java/project/domain/member/Member.java
@@ -25,6 +25,7 @@ import project.domain.member.enums.EnumUtil;
 import project.domain.member.enums.Gender;
 import project.domain.member.enums.Language;
 import project.domain.purchasehistory.PurchaseHistory;
+import project.domain.reviewrecommendstatus.ReviewRecommendStatus;
 import project.global.enums.skin.PersonalType;
 import project.domain.member.enums.Role;
 import project.global.enums.skin.SkinType;
@@ -95,6 +96,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PurchaseHistory> purchaseHistoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewRecommendStatus> reviewRecommendStatusList = new ArrayList<>();
 
     //TODO
     // 설문을 이용한 사용자의 피부 MBTI를 저장합니다.

--- a/src/main/java/project/domain/review/Review.java
+++ b/src/main/java/project/domain/review/Review.java
@@ -8,6 +8,7 @@ import project.domain.member.Member;
 import project.domain.review.dto.ReviewRequest;
 import project.domain.review.dto.ReviewRequest.ImageBodyDTO;
 import project.domain.reviewimage.ReviewImage;
+import project.domain.reviewrecommendstatus.ReviewRecommendStatus;
 import project.domain.selectoption.SelectOption;
 
 import java.util.ArrayList;
@@ -32,6 +33,9 @@ public class Review extends BaseEntity {
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<SelectOption> selectOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewRecommendStatus> reviewRecommendStatusList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/project/domain/review/controller/ReviewController.java
+++ b/src/main/java/project/domain/review/controller/ReviewController.java
@@ -16,6 +16,7 @@ import project.domain.review.dto.ReviewRequest.EditReviewBodyDTO;
 import project.domain.review.dto.ReviewResponse;
 import project.domain.review.dto.ReviewResponse.ReviewDTO;
 import project.domain.review.dto.ReviewResponse.ReviewListDTO;
+import project.domain.review.dto.ReviewResponse.ReviewOptionListDTO;
 import project.domain.review.service.ReviewService;
 import project.global.response.ApiResponse;
 import project.global.security.annotation.LoginMember;
@@ -35,7 +36,7 @@ public class ReviewController {
             description = "입력한 아이템 ID에 해당하는 아이템 리뷰 옵션을 조회합니다."
     )
     @GetMapping("/{itemId}/option")
-    public ApiResponse<ReviewResponse.ReviewOptionListDTO> getReviewOption(
+    public ApiResponse<ReviewOptionListDTO> getReviewOption(
             @Parameter(description = "아이템 ID") @PathVariable Long itemId
     ) {
         return reviewService.getReviewOption(itemId);
@@ -47,9 +48,10 @@ public class ReviewController {
     )
     @GetMapping("/{itemId}")
     public ApiResponse<ReviewListDTO> getReview(
+            @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "아이템 ID") @PathVariable Long itemId
     ) {
-        return reviewService.getReview(itemId);
+        return reviewService.getReview(member, itemId);
     }
 
     @Operation(
@@ -141,12 +143,12 @@ public class ReviewController {
             summary = "리뷰 추천수 업데이트",
             description = "리뷰 추천수를 업데이트합니다."
     )
-    @PatchMapping("/recommend/{reviewId}/{type}")
+    @PatchMapping("/recommend/{reviewId}")
     public ApiResponse<Void> updateRecommend(
-            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId,
-            @Parameter(description = "증(increase)/감(decrease)") @PathVariable String type
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId
     ) {
-        return reviewService.recommendReview(reviewId, type);
+        return reviewService.recommendReview(member.getId(), reviewId);
     }
 
 }

--- a/src/main/java/project/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/project/domain/review/dto/ReviewResponse.java
@@ -1,6 +1,7 @@
 package project.domain.review.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,6 +51,8 @@ public abstract class ReviewResponse {
         private List<String> reviewImages;
         private int recommend;
         private List<SelectOptionDTO> options;
+        @JsonProperty("isRecommend")
+        private boolean isRecommend;
         @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
         private LocalDateTime updatedAt;
     }

--- a/src/main/java/project/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/project/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,23 @@
 package project.domain.review.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import project.domain.review.Review;
 
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByItemId(Long itemId);
+
+    @Query("""
+            SELECT r FROM Review r
+            LEFT JOIN FETCH r.reviewRecommendStatusList rrs
+            WHERE (r.item.id = :itemId)
+            AND rrs.member.id = :memberId
+            AND rrs.isRecommend = true
+            """)
+    List<Review> findBMemberRecommendedWithReviewStatus(
+            @Param("itemId") Long itemId,
+            @Param("memberId") Long memberId);
 }

--- a/src/main/java/project/domain/reviewoption/ReviewOption.java
+++ b/src/main/java/project/domain/reviewoption/ReviewOption.java
@@ -1,15 +1,11 @@
 package project.domain.reviewoption;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.domain.common.BaseEntity;
-import project.domain.reviewoptionlist.ReviewOptionList;
-
-import java.util.ArrayList;
-import java.util.List;
+import project.domain.subcategory.SubCategory;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -23,8 +19,9 @@ public class ReviewOption extends BaseEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "reviewOption", cascade = CascadeType.ALL, fetch = LAZY)
-    private List<ReviewOptionList> reviewOptionList = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "sub_category_id")
+    private SubCategory subCategory;
 
     private String name;
 
@@ -34,6 +31,4 @@ public class ReviewOption extends BaseEntity {
 
     private String opt3;
 
-    @Nullable
-    private String opt4;
 }

--- a/src/main/java/project/domain/reviewoption/repository/ReviewOptionRepository.java
+++ b/src/main/java/project/domain/reviewoption/repository/ReviewOptionRepository.java
@@ -3,5 +3,9 @@ package project.domain.reviewoption.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.domain.reviewoption.ReviewOption;
 
+import java.util.List;
+
 public interface ReviewOptionRepository extends JpaRepository<ReviewOption, Long> {
+
+    List<ReviewOption> findBySubCategoryId(Long subCategoryId);
 }

--- a/src/main/java/project/domain/reviewoptionlist/repository/ReviewOptionListRepository.java
+++ b/src/main/java/project/domain/reviewoptionlist/repository/ReviewOptionListRepository.java
@@ -1,7 +1,0 @@
-package project.domain.reviewoptionlist.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import project.domain.reviewoptionlist.ReviewOptionList;
-
-public interface ReviewOptionListRepository extends JpaRepository<ReviewOptionList, Long> {
-}

--- a/src/main/java/project/domain/reviewrecommendstatus/ReviewRecommendStatus.java
+++ b/src/main/java/project/domain/reviewrecommendstatus/ReviewRecommendStatus.java
@@ -1,0 +1,44 @@
+package project.domain.reviewrecommendstatus;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.domain.common.BaseEntity;
+import project.domain.member.Member;
+import project.domain.review.Review;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewRecommendStatus extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    private boolean isRecommend;
+
+    @Builder
+    public ReviewRecommendStatus(Member member, Review review, boolean isRecommend) {
+        this.member = member;
+        this.review = review;
+        this.isRecommend = isRecommend;
+    }
+
+    public void updateIsRecommend() {
+        this.isRecommend = !this.isRecommend;
+    }
+}

--- a/src/main/java/project/domain/reviewrecommendstatus/repository/ReviewRecommendStatusRepository.java
+++ b/src/main/java/project/domain/reviewrecommendstatus/repository/ReviewRecommendStatusRepository.java
@@ -1,0 +1,12 @@
+package project.domain.reviewrecommendstatus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.domain.reviewrecommendstatus.ReviewRecommendStatus;
+
+import java.util.List;
+
+public interface ReviewRecommendStatusRepository extends JpaRepository<ReviewRecommendStatus, Long> {
+
+    List<ReviewRecommendStatus> findByMemberId(Long memberId);
+
+}

--- a/src/main/java/project/domain/selectoption/repository/SelectOptionRepository.java
+++ b/src/main/java/project/domain/selectoption/repository/SelectOptionRepository.java
@@ -1,10 +1,12 @@
 package project.domain.selectoption.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import project.domain.selectoption.SelectOption;
 
 import java.util.List;
 
 public interface SelectOptionRepository extends JpaRepository<SelectOption, Long> {
     List<SelectOption> findByReviewIdIn(List<Long> reviewId);
+
 }


### PR DESCRIPTION
## #️⃣ 요약 설명

## 📝 작업 내용

1. 기존 리뷰 옵션 테이블에서 중복되는 레코드 수를 줄이기 위해 메이크업 제품들만 리뷰 옵션 테이블을 따로 뺴는 작업
2. 리뷰 추천시 추천상태 true되서 연속 추천 못하게 하기
3.상품 추천 테이블에 소카테고리 필드 추가

Resolves: #51 #53 

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진


> ### 1. 상품 조회시 로그인 유저의 추천 상태 추가
> <img width="1399" alt="리뷰 조회시 상태값" src="https://github.com/user-attachments/assets/401be9e7-94c3-4bb0-ad4a-8a2c5e829310" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
