### PR TITLE
[FIX] mbti 설문 내용 조회 기능수정

### DIFF
--- a/src/main/java/project/domain/mbti/MbtiQuestion.java
+++ b/src/main/java/project/domain/mbti/MbtiQuestion.java
@@ -21,26 +21,23 @@ public class MbtiQuestion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private int questionId;
-
-    @Column(nullable = false, length = 255)
     private String question;
 
-    @Column(nullable = false)
-    private String answer;
+    // 위의 질문을 골랐을 경우
+    private String optionOText;
+    private Long optionONextId;
 
-    @Column(nullable = false)
+    // 해당 질문을 골랐을 경우
+    private String optionXText;
+    private Long optionXNextId;
+
+    @Enumerated(EnumType.STRING)
+    private Language language;
+
     @Enumerated(EnumType.STRING)
     private SkinAxis axis;
 
     @Enumerated(EnumType.STRING)
     private Step step;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private Language language;
-
-    private int nextQuestionId;
 
 }

--- a/src/main/java/project/domain/mbti/SkinAxis.java
+++ b/src/main/java/project/domain/mbti/SkinAxis.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SkinAxis {
 
-    SKIN_TYPE("피부타입"),
+    SKINTYPE("피부타입"),
     PIGMENT("색소"),     // 색소축
     MOISTURE("수분/유분"),    // 수분/유분 축
     REACTIVITY("반응성");   // 반응성 축

--- a/src/main/java/project/domain/mbti/controller/MbtiQuestionController.java
+++ b/src/main/java/project/domain/mbti/controller/MbtiQuestionController.java
@@ -3,14 +3,17 @@ package project.domain.mbti.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import project.domain.mbti.dto.MbtiQuestionResponse.QuestionInfoList;
+import project.domain.mbti.dto.MbtiQuestionResponse.QuestionListDTO;
 import project.domain.mbti.service.MbtiQuestionService;
+import project.domain.member.Member;
 import project.global.response.ApiResponse;
+import project.global.security.annotation.LoginMember;
 
 @Tag(name = "피부 MBTI API", description = "피부 MBTI 관련 기능입니다.")
 @RestController
@@ -26,10 +29,23 @@ public class MbtiQuestionController {
     )
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/questions")
-    public ApiResponse<QuestionInfoList> getTestQuestion(
-        @RequestParam String axis,
+    public ApiResponse<List<QuestionListDTO>> getMbtiQuestion(
+        @LoginMember Member member,
         @RequestParam String lang
     ) {
-        return mbtiQuestionService.getQuestionInfoList(axis,lang);
+        return mbtiQuestionService.getMbtiQuestionInfoList(lang,member);
     }
+
+    @Operation(
+        summary = "피부타입 Mbti 질문 조회",
+        description = "피부타입 설문을 조회를 합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/skin-questions")
+    public ApiResponse<List<QuestionListDTO>> getSkinTypeQuestion(
+        @RequestParam String lang
+    ) {
+        return mbtiQuestionService.getSkinTypeQuestion(lang);
+    }
+
 }

--- a/src/main/java/project/domain/mbti/dto/MbtiQuestionResponse.java
+++ b/src/main/java/project/domain/mbti/dto/MbtiQuestionResponse.java
@@ -8,42 +8,37 @@ import lombok.NoArgsConstructor;
 
 public abstract class MbtiQuestionResponse {
 
-    /*
-        피부 질문정보들을 담은 리스트
-     */
-    @Getter
+
     @Builder
-    @AllArgsConstructor
+    @Getter
     @NoArgsConstructor
-    public static class QuestionInfoList {
-        List<QuestionInfo> questions;
+    @AllArgsConstructor
+    public static class QuestionListDTO {
+        private String type;
+        List<QuestionInfoDTO> questions;
     }
 
-    /*
-        피부 질문 상세질문
-     */
     @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
     @Getter
-    public static class QuestionInfo {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionInfoDTO {
 
-        int id;
-        String content;
-        List<AnswerInfo> answers;
+        private Long id;
+        private String question;
+        private OptionDTO optionO;
+        private OptionDTO optionX;
     }
 
-    /*
-        해당 질문에 대한 답변
-     */
     @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
     @Getter
-    public static class AnswerInfo {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionDTO {
 
-        int nextQuestionId;
-        String answer;
-        private Boolean isResult;
+        private Long nextQuestionId;
+        private String text;
+        private String value;
+        private boolean isResult;
     }
 }

--- a/src/main/java/project/domain/mbti/repository/MbtiQuestionRepository.java
+++ b/src/main/java/project/domain/mbti/repository/MbtiQuestionRepository.java
@@ -12,15 +12,25 @@ import project.domain.member.enums.Language;
 
 public interface MbtiQuestionRepository extends JpaRepository<MbtiQuestion, Long> {
 
-    List<MbtiQuestion> findByAxis(SkinAxis axis);
-
     /*
         질문의 시작을 기준으로 가져오는 쿼리
      */
-    @Query("SELECT q FROM MbtiQuestion q WHERE q.axis = :axis and q.language= :lang " +
-        "ORDER BY CASE WHEN q.step = 'START' THEN 0 ELSE 1 END, q.questionId ASC")
-    List<MbtiQuestion> findByAxisOrderByStartFirst(
-        @Param("axis") SkinAxis axis,
+    @Query("SELECT q FROM MbtiQuestion q WHERE q.language = :lang "
+        + "ORDER BY  CASE WHEN q.step = 'START' THEN 0 ELSE 1 END, q.id")
+    List<MbtiQuestion> findByAllQuestions(
+        @Param("lang") Language language);
+
+    @Query("SELECT q FROM MbtiQuestion q WHERE q.language = :lang AND q.axis != 'SKINTYPE' "
+        + "ORDER BY CASE WHEN q.step = 'START' THEN 0 ELSE 1 END, q.id")
+    List<MbtiQuestion> findByAxisQuestions(
+        @Param("lang") Language language);
+
+    /*
+       피부타입 질문의 시작을 기준으로 가져오는 쿼리
+    */
+    @Query("SELECT q FROM MbtiQuestion q WHERE q.language = :lang AND q.axis = 'SKINTYPE' "
+        + "ORDER BY CASE WHEN q.step = 'START' THEN 0 ELSE 1 END")
+    List<MbtiQuestion> findBySkinQuestion(
         @Param("lang") Language language);
 
 

--- a/src/main/java/project/domain/mbti/service/MbtiQuestionService.java
+++ b/src/main/java/project/domain/mbti/service/MbtiQuestionService.java
@@ -1,34 +1,69 @@
 package project.domain.mbti.service;
 
+import java.util.Arrays;
 import java.util.FormatterClosedException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.domain.mbti.MbtiQuestion;
 import project.domain.mbti.SkinAxis;
 import project.domain.mbti.dto.MbtiQuestionConverter;
 import project.domain.mbti.dto.MbtiQuestionResponse;
-import project.domain.mbti.dto.MbtiQuestionResponse.QuestionInfoList;
+import project.domain.mbti.dto.MbtiQuestionResponse.QuestionListDTO;
 import project.domain.mbti.repository.MbtiQuestionRepository;
+import project.domain.member.Member;
 import project.domain.member.enums.Language;
+import project.domain.member.repository.MemberRepository;
 import project.global.response.ApiResponse;
 import project.global.response.exception.GeneralException;
 import project.global.response.status.ErrorStatus;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MbtiQuestionService {
 
     private final MbtiQuestionRepository mbtiQuestionRepository;
+    private final MemberRepository memberRepository;
 
-    public ApiResponse<QuestionInfoList> getQuestionInfoList(String axis,String lang) {
+    public ApiResponse<List<QuestionListDTO>> getMbtiQuestionInfoList(String lang, Member member) {
 
-        List<MbtiQuestion> byAxis = mbtiQuestionRepository.findByAxisOrderByStartFirst(SkinAxis.valueOf(axis),
-            Language.getLanguage(lang));
-        QuestionInfoList questionInfoList = MbtiQuestionConverter.toQuestionInfoList(byAxis);
-
-        return ApiResponse.onSuccess(questionInfoList);
+        memberRepository.findById(member.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MAIL_NOT_FOUND));
+        // 스킨타입이 있으면 스킨타입 질문을 제외하고 보내준다.
+        // 스키타입이 없으면 스키타입 질문을 포함해서 보내준다.
+        if (member.getSkinType() == null) {
+            List<MbtiQuestion> questionByALL = getQuestionByALL(member.getLang());
+            List<QuestionListDTO> questionListDTO = MbtiQuestionConverter.toQuestionListDTO(
+                questionByALL);
+            return ApiResponse.onSuccess(questionListDTO);
+        } else {
+            List<MbtiQuestion> questionByAxis = getQuestionByAxis(member.getLang());
+            List<QuestionListDTO> questionListDTO = MbtiQuestionConverter.toQuestionListDTO(
+                questionByAxis);
+            return ApiResponse.onSuccess(questionListDTO);
+        }
     }
+
+    public ApiResponse<List<QuestionListDTO>> getSkinTypeQuestion(String lang) {
+        Language language = Language.getLanguage(lang);
+        List<MbtiQuestion> questionBySkinType = getQuestionBySkinType(language);
+        return ApiResponse.onSuccess(MbtiQuestionConverter.toQuestionListDTO(questionBySkinType));
+    }
+
+    public List<MbtiQuestion> getQuestionByALL(Language lang) {
+        return mbtiQuestionRepository.findByAllQuestions(lang);
+    }
+
+    public List<MbtiQuestion> getQuestionBySkinType(Language lang) {
+        return mbtiQuestionRepository.findBySkinQuestion(lang);
+    }
+
+    public List<MbtiQuestion> getQuestionByAxis(Language lang) {
+        return mbtiQuestionRepository.findByAxisQuestions(lang);
+    }
+
 }

--- a/src/main/java/project/global/enums/skin/AxisType.java
+++ b/src/main/java/project/global/enums/skin/AxisType.java
@@ -1,10 +1,20 @@
 package project.global.enums.skin;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum AxisType {
-    E,
-    B,
-    F,
-    S,
-    R,
-    W
+    E(-5),
+    B(-4),
+    F(-6),
+    S(-7),
+    R(-8),
+    W(-9);
+
+    private final int code;
+
 }

--- a/src/main/java/project/global/enums/skin/SkinType.java
+++ b/src/main/java/project/global/enums/skin/SkinType.java
@@ -6,12 +6,13 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum SkinType {
-    A("건성"),
-    O("지성"),
-    N("복합성");
+public enum SkinType{
+    A("건성", -1),
+    O("지성", -3),
+    N("복합성", -2);
 
     private final String string;
+    private final int code;
 
     public static SkinType getSkinType(String skinType) {
         return Arrays.stream(SkinType.values())

--- a/src/main/java/project/global/util/QuestionUtil.java
+++ b/src/main/java/project/global/util/QuestionUtil.java
@@ -1,0 +1,26 @@
+package project.global.util;
+
+import project.global.enums.skin.AxisType;
+import project.global.enums.skin.SkinType;
+
+public abstract class QuestionUtil {
+
+    public static String findEnumByCode(Long code) {
+        // 1. SkinType에서 찾기
+        for (SkinType type : SkinType.values()) {
+            if (type.getCode() == code) {
+                return type.getString();
+            }
+        }
+
+        // 2. AxisType에서 찾기
+        for (AxisType type : AxisType.values()) {
+            if (type.getCode() == code) {
+                return type.toString();
+            }
+        }
+
+        // 3. 못 찾으면 null 반환
+        return null;
+    }
+}


### PR DESCRIPTION
1. 피부타입별 질문 조회 기능 수정
2. mbti 질문 조회 기능 수정 및 DB 추가

Resolves: #67

## #️⃣ 요약 설명

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
> ex) 기존 memberInfoDTO response 값에 생일을 추가했습니다.

```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
