### PR TITLE
[FEAT-83] : 챗봇 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,14 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
+    //WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // STOMP 메시지 브로커
+    implementation 'org.springframework:spring-messaging'
+    // WebClient (FastAPI HTTP 호출)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // (Optional) JSON 직렬화 Jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // 테스트 관련 코드
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/project/global/chat/controller/ChatController.java
+++ b/src/main/java/project/global/chat/controller/ChatController.java
@@ -1,0 +1,32 @@
+package project.global.chat.controller;
+
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.domain.member.Member;
+import project.global.chat.dto.ChatRequestDTO;
+import project.global.chat.dto.ChatResponseDTO;
+import project.global.chat.service.ChatService;
+import project.global.response.ApiResponse;
+import project.global.security.annotation.LoginMember;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping("/message") // 클라이언트에서 /chat/message로 보낼 경우 실행됨
+    public ApiResponse<ChatResponseDTO> handleMessage(
+        @LoginMember Member member,
+        @RequestBody ChatRequestDTO request) {
+        ChatResponseDTO response = chatService.sendToFastApi(request, member).block();
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/project/global/chat/dto/ChatRequestDTO.java
+++ b/src/main/java/project/global/chat/dto/ChatRequestDTO.java
@@ -1,0 +1,14 @@
+package project.global.chat.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRequestDTO {
+    private Long memberId;
+    private String message;
+    private String lang;
+    private List<Long> item_ids;
+}

--- a/src/main/java/project/global/chat/dto/ChatResponseDTO.java
+++ b/src/main/java/project/global/chat/dto/ChatResponseDTO.java
@@ -1,0 +1,19 @@
+package project.global.chat.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ChatResponseDTO {
+
+    private String output;
+    private List<Item> itemList;
+
+    @Data
+    public static class Item {
+
+        private Long item_id;
+        private String item_name;
+        private String item_image;
+    }
+}

--- a/src/main/java/project/global/chat/service/ChatService.java
+++ b/src/main/java/project/global/chat/service/ChatService.java
@@ -1,0 +1,24 @@
+package project.global.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import project.domain.member.Member;
+import project.global.chat.dto.ChatRequestDTO;
+import project.global.chat.dto.ChatResponseDTO;
+import reactor.core.publisher.Mono;
+
+
+@Service
+public class ChatService {
+
+    private final WebClient webClient = WebClient.create("http://your-ml-api:8000");
+
+    public Mono<ChatResponseDTO> sendToFastApi(ChatRequestDTO request, Member member) {
+        request.setMemberId(member.getId());
+        return webClient.post()
+            .uri("http://fastapi/chat")
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(ChatResponseDTO.class);
+    }
+}


### PR DESCRIPTION
1. get 요청으로 사용자에게 text와 id값을 받습니다.
2. webCLient를 이용해 mlserver와 통신합니다.


> ### WebCLient를 이용해 ml 서버와 통신을 합니다.
```java
private final WebClient webClient = WebClient.create("http://your-ml-api:8000");

    public Mono<ChatResponseDTO> sendToFastApi(ChatRequestDTO request, Member member) {
        request.setMemberId(member.getId());
        return webClient.post()
            .uri("http://fastapi/chat")
            .bodyValue(request)
            .retrieve()
            .bodyToMono(ChatResponseDTO.class);
    }
```
> ### ResponseDTO와 RequestDTO를 이용하여 요청을 응답을 줍니다.
```java
package project.global.chat.dto;

import java.util.List;
import lombok.Getter;
import lombok.Setter;

@Getter
@Setter
public class ChatRequestDTO {
    private Long memberId;
    private String message;
    private String lang;
    private List<Long> item_ids;
}


package project.global.chat.dto;

import java.util.List;
import lombok.Data;

@Data
public class ChatResponseDTO {

    private String output;
    private List<Item> itemList;

    @Data
    public static class Item {

        private Long item_id;
        private String item_name;
        private String item_image;
    }
}
```

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
