### PR TITLE
[FIX-89] : 아이템 조회 비회원기능 추가

### DIFF
--- a/src/main/java/project/domain/item/service/ItemSearchService.java
+++ b/src/main/java/project/domain/item/service/ItemSearchService.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,20 +45,24 @@ public class ItemSearchService {
         서브 카테고리 별 아이템 조회
          */
     public ApiResponse<ItemSearchResultDTO> getItemsBySubCategory(
-            String subCategoryName,
-            Member member,
-            String skinIssue,
-            String priceSort
+        String subCategoryName,
+        Member member,
+        String skinIssue,
+        String priceSort
     ) {
         // 찜한 상품 Id
-        List<Long> wishListIds = wishlistRepository.findByMemberId(member.getId())
+        List<Long> wishListIds = new ArrayList<>();
+
+        if (member != null) {
+            wishListIds = wishlistRepository.findByMemberId(member.getId())
                 .stream()
                 .map(w -> w.getItem().getId())
                 .toList();
+        }
 
         // 아이템 정보와 메인 이미지를 한번에 조회
         List<Item> items = itemDynamicSort.findItemsWithDSL(
-                subCategoryName, skinIssue, priceSort);
+            subCategoryName, skinIssue, priceSort);
 
 //        if (StringUtils.hasText(skinIssue)) {
 //            // 스킨이슈에 해당하는 제품 조회
@@ -71,7 +76,8 @@ public class ItemSearchService {
             return ApiResponse.onFailure(ErrorStatus.ITEM_NOT_FOUND, null);
         }
 
-        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items, wishListIds);
+        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items,
+            wishListIds);
         return ApiResponse.onSuccess(itemSearchResultDTO);
     }
 
@@ -79,30 +85,36 @@ public class ItemSearchService {
           카테고리 별 구매내역순서 아이템 조회
      */
     public ApiResponse<List<ItemSearchInfoDTO>> getItemsByCategoryOrderByCount(
-            Member member,
-            String categoryName) {
+        Member member,
+        String categoryName) {
         // 찜한 상품 Id
-        List<WishList> wishLists = wishlistRepository.findByMemberId(member.getId());
-        List<Long> wishListIds = wishLists.stream()
+        // 찜한 상품 Id
+        List<Long> wishListIds = new ArrayList<>();
+
+        if (member != null) {
+            List<Long> fetchedIds = wishlistRepository.findByMemberId(member.getId())
+                .stream()
                 .map(w -> w.getItem().getId())
                 .toList();
+            wishListIds.addAll(fetchedIds);
+        }
 
         Long categoryId;
         if (categoryName == null || categoryName.isEmpty()) {
             categoryId = null;
         } else {
             Category category = categoryRepository.findByName(categoryName).orElseThrow(
-                    () -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
+                () -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
             categoryId = category.getId();
         }
 
         List<Item> top10ItemsByCategory = itemRepository.findTop10ItemsByCategory(
-                categoryId);
+            categoryId);
 
         List<ItemSearchInfoDTO> itemSearchInfoDTO = top10ItemsByCategory.stream()
-                .map(ti ->
-                        ItemSearchConverter.toItemSearchDetailInfoDTO(ti, wishListIds.contains(ti.getId())))
-                .toList();
+            .map(ti ->
+                ItemSearchConverter.toItemSearchDetailInfoDTO(ti, wishListIds.contains(ti.getId())))
+            .toList();
 
         return ApiResponse.onSuccess(itemSearchInfoDTO);
     }
@@ -113,10 +125,14 @@ public class ItemSearchService {
     public ApiResponse<ItemSearchResultDTO> searchByKeyword(Member member, String keyword) {
 
         // 찜한 상품 Id
-        List<WishList> wishLists = wishlistRepository.findByMemberId(member.getId());
-        List<Long> wishListIds = wishLists.stream()
+        List<Long> wishListIds = new ArrayList<>();
+
+        if (member != null) {
+            wishListIds = wishlistRepository.findByMemberId(member.getId())
+                .stream()
                 .map(w -> w.getItem().getId())
                 .toList();
+        }
 
         // 아이템 정보와 메인 이미지를 한번에 조회
         List<Item> items = itemRepository.findByKeywordWithMainImage(keyword);
@@ -124,54 +140,57 @@ public class ItemSearchService {
             return ApiResponse.onFailure(ErrorStatus.ITEM_NOT_FOUND, null);
         }
 
-        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items, wishListIds);
+        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items,
+            wishListIds);
         return ApiResponse.onSuccess(itemSearchResultDTO);
     }
 
     /*
     개선된 검색 키워드에 맞는 아이템 조회(ElasticSearch 활용)
      */
-    public ApiResponse<ItemSearchResultDTO> AdvancedSearchByKeyword(Member member, String keyword) throws IOException {
+    public ApiResponse<ItemSearchResultDTO> AdvancedSearchByKeyword(Member member, String keyword)
+        throws IOException {
         SearchRequest searchRequest = SearchRequest.of(s -> s
-                .index("items")
-                .query(q -> q
-                        .bool(b -> b
-                                // 상품명 정확 매칭 (최우선)
-                                .should(sh -> sh
-                                        .match(m -> m.field("name").query(keyword).boost(5.0f))
-                                )
+            .index("items")
+            .query(q -> q
+                .bool(b -> b
+                    // 상품명 정확 매칭 (최우선)
+                    .should(sh -> sh
+                        .match(m -> m.field("name").query(keyword).boost(5.0f))
+                    )
 
-                                // 상품명 포함 (중간 우선순위)
-                                .should(sh -> sh
-                                        .wildcard(w -> w.field("name").value("*" + keyword + "*").boost(2.0f)))
+                    // 상품명 포함 (중간 우선순위)
+                    .should(sh -> sh
+                        .wildcard(w -> w.field("name").value("*" + keyword + "*").boost(2.0f)))
 
-                                // n-gram 방식 (각 글자별로)
-                                .should(sh -> sh
-                                        .matchPhrase(mp -> mp
-                                                .field("name")
-                                                .query(keyword)
-                                                .slop(1)  // 단어 순서 바뀌어도 허용
-                                                .boost(1.5f)))
+                    // n-gram 방식 (각 글자별로)
+                    .should(sh -> sh
+                        .matchPhrase(mp -> mp
+                            .field("name")
+                            .query(keyword)
+                            .slop(1)  // 단어 순서 바뀌어도 허용
+                            .boost(1.5f)))
 
-                                // Fuzzy 검색 (오타 허용)
-                                .should(sh -> sh
-                                        .fuzzy(f -> f
-                                                .field("name")
-                                                .value(keyword)
-                                                .fuzziness("2")
-                                                .prefixLength(0)  // 접두사 길이 0
-                                                .maxExpansions(50)
-                                                .boost(1.0f)))
-                        ))
-                .sort(so -> so.score(sc -> sc.order(SortOrder.Desc))) // 점수 높은 순
+                    // Fuzzy 검색 (오타 허용)
+                    .should(sh -> sh
+                        .fuzzy(f -> f
+                            .field("name")
+                            .value(keyword)
+                            .fuzziness("2")
+                            .prefixLength(0)  // 접두사 길이 0
+                            .maxExpansions(50)
+                            .boost(1.0f)))
+                ))
+            .sort(so -> so.score(sc -> sc.order(SortOrder.Desc))) // 점수 높은 순
         );
 
         // Elasticsearch 검색 실행 후 id만 뽑아내기
-        SearchResponse<ItemDocument> response = searchElasticsearchClient.search(searchRequest, ItemDocument.class);
+        SearchResponse<ItemDocument> response = searchElasticsearchClient.search(searchRequest,
+            ItemDocument.class);
         List<Long> itemIds = response.hits().hits().stream()
-                .map(hit -> hit.source().getId())
-                .filter(Objects::nonNull)
-                .toList();
+            .map(hit -> hit.source().getId())
+            .filter(Objects::nonNull)
+            .toList();
 
         // 검색 결과가 없으면 빈 결과 반환
         if (itemIds.isEmpty()) {
@@ -179,10 +198,14 @@ public class ItemSearchService {
         }
 
         // 찜한 상품 Id
-        List<WishList> wishLists = wishlistRepository.findByMemberId(member.getId());
-        List<Long> wishListIds = wishLists.stream()
+        List<Long> wishListIds = new ArrayList<>();
+
+        if (member != null) {
+            wishListIds = wishlistRepository.findByMemberId(member.getId())
+                .stream()
                 .map(w -> w.getItem().getId())
                 .toList();
+        }
 
         // 아이템 정보와 메인 이미지를 한번에 조회
         List<Item> items = itemRepository.findItemByItemIdsWithMainImage(itemIds);
@@ -190,7 +213,8 @@ public class ItemSearchService {
             return ApiResponse.onFailure(ErrorStatus.ITEM_NOT_FOUND, null);
         }
 
-        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items, wishListIds);
+        ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(items,
+            wishListIds);
         return ApiResponse.onSuccess(itemSearchResultDTO);
     }
 
@@ -199,17 +223,21 @@ public class ItemSearchService {
     비건 제품 조회
      */
     public ApiResponse<ItemSearchResultDTO> getVeganItems(
-            Member member, String subCategory, String skinIssue, String priceSort) {
+        Member member, String subCategory, String skinIssue, String priceSort) {
 
         // 찜한 상품 Id
-        List<WishList> wishLists = wishlistRepository.findByMemberId(member.getId());
-        List<Long> wishListIds = wishLists.stream()
+        List<Long> wishListIds = new ArrayList<>();
+
+        if (member != null) {
+            wishListIds = wishlistRepository.findByMemberId(member.getId())
+                .stream()
                 .map(w -> w.getItem().getId())
                 .toList();
+        }
 
         // 아이템 정보와 메인 이미지를 한번에 조회
         List<Item> veganItems = itemDynamicSort.findVeganItemsWithDSL(
-                subCategory, skinIssue, priceSort);
+            subCategory, skinIssue, priceSort);
 
 //        if (StringUtils.hasText(skinIssue)) {
 //            veganItems = itemRepository.findByVeganItemsAndSkinIssueWithMainImage(subCategory, skinIssue);
@@ -221,18 +249,19 @@ public class ItemSearchService {
 //        }
 
         ItemSearchResultDTO itemSearchResultDTO = ItemSearchConverter.toItemSearchInfoDTO(
-                veganItems, wishListIds);
+            veganItems, wishListIds);
         return ApiResponse.onSuccess(itemSearchResultDTO);
     }
 
     public ApiResponse<List<Top10ItemsInfoDTO>> getTop10Items(List<PopularItemDTO> top10Items) {
         List<Long> itemIds = top10Items.stream()
-                .map(PopularItemDTO::getItemId)
-                .toList();
+            .map(PopularItemDTO::getItemId)
+            .toList();
 
         List<Item> items = itemRepository.findItemByItemIdsWithMainImage(itemIds);
 
-        List<Top10ItemsInfoDTO> top10ItemsInfoDTOs = ItemSearchConverter.toTop10ItemsInfoDTOs(items);
+        List<Top10ItemsInfoDTO> top10ItemsInfoDTOs = ItemSearchConverter.toTop10ItemsInfoDTOs(
+            items);
         return ApiResponse.onSuccess(top10ItemsInfoDTOs);
     }
 

--- a/src/main/java/project/global/security/util/LoginArgumentResolver.java
+++ b/src/main/java/project/global/security/util/LoginArgumentResolver.java
@@ -1,5 +1,6 @@
 package project.global.security.util;
 
+import lombok.extern.slf4j.Slf4j;
 import project.domain.member.Member;
 import project.domain.member.repository.MemberRepository;
 import project.global.security.annotation.LoginMember;
@@ -13,6 +14,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
+@Slf4j
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     private final MemberRepository memberRepository;
 
@@ -33,8 +35,9 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
         }
 
         String email = authentication.getName(); // JwtAuthFilter에서 설정한 email
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("인증된 사용자를 찾을 수 없습니다."));
+        log.info(email);
+        return memberRepository.findByEmail(email).orElse(null);
+//                .orElseThrow(() -> new IllegalArgumentException("인증된 사용자를 찾을 수 없습니다."));
 
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명

1. 인증 resolver에 비회원일경우 member에 null값을 허용하게했습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
> ex) 기존 memberInfoDTO response 값에 생일을 추가했습니다.

```java
    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
        // SecurityContextHolder에서 email 가져오기
        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
        if (authentication == null || authentication.getPrincipal() == null) {
            return null;
        }

        String email = authentication.getName(); // JwtAuthFilter에서 설정한 email
        log.info(email);
        return memberRepository.findByEmail(email).orElse(null);
//                .orElseThrow(() -> new IllegalArgumentException("인증된 사용자를 찾을 수 없습니다."));

    }
```

```java
// 찜한 상품 Id
        List<Long> wishListIds = new ArrayList<>();

        if (member != null) {
            List<Long> fetchedIds = wishlistRepository.findByMemberId(member.getId())
                .stream()
                .map(w -> w.getItem().getId())
                .toList();
            wishListIds.addAll(fetchedIds);
        }
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
